### PR TITLE
many: add CI and fix package-lint/byte-compile warnings

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,27 +3,35 @@ name: CI
 on:
   pull_request:
   push:
-    paths-ignore:
-    - '**.md'
 
 jobs:
-  build:
+  check:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         emacs_version:
           - 27.1
+          - 27.2
+          - 28.2
+          - 29.4
+          - 30.2
           - snapshot
+        # ignore_warnings:
+        #   - true
+        include:
+          - emacs_version: snapshot
+            ignore_warnings: false
     steps:
+    - uses: actions/checkout@v2
     - uses: purcell/setup-emacs@master
       with:
         version: ${{ matrix.emacs_version }}
-
-    - uses: actions/checkout@v1
-    - name: Run tests
-      run: |
-        export PATH="$HOME/bin:$PATH"
-        wget 'https://raw.githubusercontent.com/flycheck/emacs-travis/master/emacs-travis.mk'
-        make -f emacs-travis.mk install_cask
-        cask install
-        cask exec ert-runner
+    - uses: leotaku/elisp-check@master
+      with:
+        check: melpa
+        file: erc-matterircd.el
+    - uses: leotaku/elisp-check@master
+      with:
+        check: ert
+        file: test/erc-matterircd-test.el

--- a/erc-matterircd.el
+++ b/erc-matterircd.el
@@ -435,7 +435,7 @@ Defaults to the current buffer if none specified."
 Defaults to 10 lines if none specified."
   (if (eq 'matterircd (erc-network))
       (let ((target (erc-default-target))
-            (lines (or (and (integerp num-lines) num-lines)
+            (lines (or (and num-lines (string-to-number num-lines))
                        10)))
         (erc-message "PRIVMSG" (format "mattermost scrollback %s %d" target lines)))
     (erc-display-message nil 'error (current-buffer) 'not-matterircd)))

--- a/erc-matterircd.el
+++ b/erc-matterircd.el
@@ -332,7 +332,7 @@ to, edit or delete a post."
         (handled nil))
     (when (string= sender "mattermost")
       (pcase contents
-        ((rx bos "set viewed for " (let channel (group (one-or-more any))) eos)
+        ((rx bos "set viewed for " (let channel (group (one-or-more nonl))) eos)
          ;; channel name doesn't contain # prefix but it does in our
          ;; list of pending responses
          (setq channel (concat "#" channel))
@@ -440,7 +440,8 @@ Defaults to 10 lines if none specified."
         (erc-message "PRIVMSG" (format "mattermost scrollback %s %d" target lines)))
     (erc-display-message nil 'error (current-buffer) 'not-matterircd)))
 
-(defalias 'erc-cmd-SCROLLBACK #'erc-matterircd-scrollback)
+;; ERC dispatches /SCROLLBACK by calling erc-cmd-SCROLLBACK
+(fset 'erc-cmd-SCROLLBACK #'erc-matterircd-scrollback)
 
 (defun erc-matterircd--pending-requests-timeout ()
   "Timer function called when the pending requests timer expires."
@@ -491,7 +492,8 @@ will always resend if FORCE."
                                   #'erc-matterircd--pending-requests-timeout))))
     (erc-display-message nil 'error channel 'not-matterircd)))
 
-(defalias 'erc-cmd-UPDATELASTVIEWED #'erc-matterircd-updatelastviewed)
+;; ERC dispatches /UPDATELASTVIEWED by calling erc-cmd-UPDATELASTVIEWED
+(fset 'erc-cmd-UPDATELASTVIEWED #'erc-matterircd-updatelastviewed)
 
 (defvar erc-matterircd--last-buffer nil
   "The last matterircd buffer which was viewed.")
@@ -529,8 +531,9 @@ will always resend if FORCE."
 (defvar erc-matterircd--run-last-hook-functions
   `(,#'erc-matterircd-buttonize-from-text-properties))
 
-(defvar erc-message-english-not-matterircd
-  "This command is specific to matterircd only.")
+;; ERC's catalog system looks up erc-message-CATALOG-ENTRY by name
+(set 'erc-message-english-not-matterircd
+     "This command is specific to matterircd only.")
 
 (define-erc-module matterircd nil
   "Integrate ERC with matterircd."

--- a/erc-matterircd.el
+++ b/erc-matterircd.el
@@ -532,8 +532,9 @@ will always resend if FORCE."
   `(,#'erc-matterircd-buttonize-from-text-properties))
 
 ;; ERC's catalog system looks up erc-message-CATALOG-ENTRY by name
-(set 'erc-message-english-not-matterircd
-     "This command is specific to matterircd only.")
+(with-suppressed-warnings ((free-vars erc-message-english-not-matterircd))
+  (set 'erc-message-english-not-matterircd
+       "This command is specific to matterircd only."))
 
 (define-erc-module matterircd nil
   "Integrate ERC with matterircd."

--- a/erc-matterircd.el
+++ b/erc-matterircd.el
@@ -224,8 +224,8 @@ bold face instead."
     (while (or (re-search-forward "\\(\\*\\*\\([^\\*]+?\\)\\*\\*\\)" nil t)
                (re-search-forward "\\_<\\(__\\([^_]+?\\)__\\)\\_>" nil t))
       (let ((message (match-string 2))
-             (start (match-beginning 0))
-             (end (match-end 0)))
+            (start (match-beginning 0))
+            (end (match-end 0)))
         (put-text-property start end
                            'display
                            (propertize message
@@ -377,21 +377,21 @@ to, edit or delete a post."
   "Get the list of context IDs and locations for BUFFER in MRU order.
 
 Defaults to the current buffer if none specified."
-    (with-current-buffer (or buffer (current-buffer))
-      (save-excursion
-        (goto-char (point-min))
-        (let ((context-ids nil)
-              (match nil))
-          (while (setq match (text-property-search-forward 'erc-matterircd-context-id))
-            (let ((id (prop-match-value match)))
-              (unless (alist-get id context-ids nil nil #'equal)
-                (push (cons (prop-match-value match)
-                            (cons (current-buffer)
-                                  ;; after searching point is just past the
-                                  ;; location
-                                  (1- (point))))
-                      context-ids))))
-          context-ids))))
+  (with-current-buffer (or buffer (current-buffer))
+    (save-excursion
+      (goto-char (point-min))
+      (let ((context-ids nil)
+            (match nil))
+        (while (setq match (text-property-search-forward 'erc-matterircd-context-id))
+          (let ((id (prop-match-value match)))
+            (unless (alist-get id context-ids nil nil #'equal)
+              (push (cons (prop-match-value match)
+                          (cons (current-buffer)
+                                ;; after searching point is just past the
+                                ;; location
+                                (1- (point))))
+                    context-ids))))
+        context-ids))))
 
 (defun erc-matterircd--get-docsig-for-context-id (id context-ids)
   "Get the docsig for ID from the list of CONTEXT-IDS."
@@ -406,28 +406,28 @@ Defaults to the current buffer if none specified."
   "Complete context-ids for replies."
   (when (and (eq 'matterircd (erc-network))
              (not (null (string-match-p "^@@[0-9]\\{0,3\\}$" (erc-user-input)))))
-        ;; find the list of context-ids in the current buffer
-        (let* ((context-ids (erc-matterircd--context-ids))
-               (candidates
-                (mapcar (lambda (id) (cons (concat "@@" (car id)) (cdr id))) context-ids))
-              (bounds (bounds-of-thing-at-point 'word)))
-          (list (car bounds) (cdr bounds)
-                candidates
-                :exclusive 'no
-                :annotation-function (lambda (id)
-                                       (let ((docsig
-                                              (erc-matterircd--get-docsig-for-context-id
-                                               id candidates)))
-                                         (truncate-string-to-width docsig 40)))
-                :company-docsig (lambda (id)
-                                  (erc-matterircd--get-docsig-for-context-id
-                                   id candidates))
-                :company-doc-buffer (lambda (id)
-                                      (company-doc-buffer
-                                       (erc-matterircd--get-docsig-for-context-id
-                                        id candidates)))
-                :company-location (lambda (id)
-                                    (cdr (alist-get id context-ids nil nil #'equal)))))))
+    ;; find the list of context-ids in the current buffer
+    (let* ((context-ids (erc-matterircd--context-ids))
+           (candidates
+            (mapcar (lambda (id) (cons (concat "@@" (car id)) (cdr id))) context-ids))
+           (bounds (bounds-of-thing-at-point 'word)))
+      (list (car bounds) (cdr bounds)
+            candidates
+            :exclusive 'no
+            :annotation-function (lambda (id)
+                                   (let ((docsig
+                                          (erc-matterircd--get-docsig-for-context-id
+                                           id candidates)))
+                                     (truncate-string-to-width docsig 40)))
+            :company-docsig (lambda (id)
+                              (erc-matterircd--get-docsig-for-context-id
+                               id candidates))
+            :company-doc-buffer (lambda (id)
+                                  (company-doc-buffer
+                                   (erc-matterircd--get-docsig-for-context-id
+                                    id candidates)))
+            :company-location (lambda (id)
+                                (cdr (alist-get id context-ids nil nil #'equal)))))))
 
 (defun erc-matterircd-scrollback (&optional num-lines)
   "Request scrollback for the current channel of NUM-LINES.
@@ -445,10 +445,10 @@ Defaults to 10 lines if none specified."
 
 (defun erc-matterircd--pending-requests-timeout ()
   "Timer function called when the pending requests timer expires."
-   (let ((channel (caar erc-matterircd--pending-requests)))
-     (when channel
-       (with-current-buffer (erc-get-buffer channel)
-         (erc-matterircd-updatelastviewed channel t)))))
+  (let ((channel (caar erc-matterircd--pending-requests)))
+    (when channel
+      (with-current-buffer (erc-get-buffer channel)
+        (erc-matterircd-updatelastviewed channel t)))))
 
 ;; matterircd seems to concatenate multiple privmsg commands if we send
 ;; them too quickly in succession, so instead we want to only send one
@@ -460,36 +460,36 @@ Queue up pending requests so we don't overload matterircd, but
 will always resend if FORCE."
   (setq channel (or channel (erc-default-target)))
   (if (eq 'matterircd (erc-network))
-        ;; the mattermost user is fake plus we can't seem to
-        ;; updatelastviewed for the channel with ourself so skip both of
-        ;; these
-        (when (not (or (string= channel "mattermost")
-                       (string= channel (erc-current-nick))))
-          ;; if in the list delete it and add again at the end with the
-          ;; current time
-         (setq erc-matterircd--pending-requests
-               (cl-remove channel erc-matterircd--pending-requests
-                          :test #'string= :key #'car))
-         (add-to-list 'erc-matterircd--pending-requests
-                      (cons channel (time-convert nil 'integer))
-                      ;; when forced push to the front of the list
-                      (not force))
-         (when (or force (= (length erc-matterircd--pending-requests) 1))
-	    ;; force sending so as to avoid flood control as we will resend it
-            ;; ourselves later if required so we don't want to queue up a
-            ;; heap of requests
-            (erc-message "PRIVMSG"
-                         (format "mattermost updatelastviewed %s" channel)
-                         t)
-            ;; cancel any existing timer so we reset it below
-            (when (timerp erc-matterircd--pending-requests-timer)
-              (cancel-timer erc-matterircd--pending-requests-timer)
-              (setq erc-matterircd--pending-requests-timer nil)))
-          ;; ensure timer is running
-          (unless (timerp erc-matterircd--pending-requests-timer)
-            (setq erc-matterircd--pending-requests-timer
-                  (run-with-timer 5 5
-                                  #'erc-matterircd--pending-requests-timeout))))
+      ;; the mattermost user is fake plus we can't seem to
+      ;; updatelastviewed for the channel with ourself so skip both of
+      ;; these
+      (when (not (or (string= channel "mattermost")
+                     (string= channel (erc-current-nick))))
+        ;; if in the list delete it and add again at the end with the
+        ;; current time
+        (setq erc-matterircd--pending-requests
+              (cl-remove channel erc-matterircd--pending-requests
+                         :test #'string= :key #'car))
+        (add-to-list 'erc-matterircd--pending-requests
+                     (cons channel (time-convert nil 'integer))
+                     ;; when forced push to the front of the list
+                     (not force))
+        (when (or force (= (length erc-matterircd--pending-requests) 1))
+	  ;; force sending so as to avoid flood control as we will resend it
+          ;; ourselves later if required so we don't want to queue up a
+          ;; heap of requests
+          (erc-message "PRIVMSG"
+                       (format "mattermost updatelastviewed %s" channel)
+                       t)
+          ;; cancel any existing timer so we reset it below
+          (when (timerp erc-matterircd--pending-requests-timer)
+            (cancel-timer erc-matterircd--pending-requests-timer)
+            (setq erc-matterircd--pending-requests-timer nil)))
+        ;; ensure timer is running
+        (unless (timerp erc-matterircd--pending-requests-timer)
+          (setq erc-matterircd--pending-requests-timer
+                (run-with-timer 5 5
+                                #'erc-matterircd--pending-requests-timeout))))
     (erc-display-message nil 'error channel 'not-matterircd)))
 
 ;; ERC dispatches /UPDATELASTVIEWED by calling erc-cmd-UPDATELASTVIEWED

--- a/erc-matterircd.el
+++ b/erc-matterircd.el
@@ -113,7 +113,7 @@ by default as they are usually not important."
 (defun erc-matterircd-format-links ()
   "Format links sent via matterircd.
 Links use markdown syntax of [name](url) so tag name to
-open url via `browse-url-buttton-open-url'."
+open url via `browse-url-button-open-url'."
   (when (eq 'matterircd (erc-network))
     (goto-char (point-min))
     (while (re-search-forward "\\[\\([^\\[]*\\)\\](\\(.*?\\))" nil t)
@@ -143,7 +143,7 @@ open url via `browse-url-buttton-open-url'."
 (defun erc-matterircd-buttonize-from-text-properties ()
   "Buttonize text based on pre-existing text properties.
 
-Buttonize links to open url via `browse-url-buttton-open-url' and
+Buttonize links to open url via `browse-url-button-open-url' and
 thread contexts so can reply."
   (when (eq 'matterircd (erc-network))
     (dolist (props `((:property erc-matterircd-link-url
@@ -166,7 +166,7 @@ thread contexts so can reply."
 For each /gif we see two lines in the message:
 
  */gif [name](URL)*
-![GIF for 'name'](URL)
+![GIF for NAME](URL)
 
 In mattermost this is shown as:
 /gif name
@@ -354,7 +354,7 @@ to, edit or delete a post."
          (when (> (length erc-matterircd--pending-requests) 0)
            (let ((channel (caar erc-matterircd--pending-requests)))
              (with-current-buffer (erc-get-buffer channel)
-               (erc-cmd-UPDATELASTVIEWED channel t))))
+               (erc-matterircd-updatelastviewed channel t))))
          ;; respects users wish to suppress responses
          (setq handled erc-matterircd-suppress-mattermost-responses))
         ((rx bos "login OK" eos)
@@ -429,7 +429,7 @@ Defaults to the current buffer if none specified."
                 :company-location (lambda (id)
                                     (cdr (alist-get id context-ids nil nil #'equal)))))))
 
-(defun erc-cmd-SCROLLBACK (&optional num-lines)
+(defun erc-matterircd-scrollback (&optional num-lines)
   "Request scrollback for the current channel of NUM-LINES.
 
 Defaults to 10 lines if none specified."
@@ -440,17 +440,19 @@ Defaults to 10 lines if none specified."
         (erc-message "PRIVMSG" (format "mattermost scrollback %s %d" target lines)))
     (erc-display-message nil 'error (current-buffer) 'not-matterircd)))
 
+(defalias 'erc-cmd-SCROLLBACK #'erc-matterircd-scrollback)
+
 (defun erc-matterircd--pending-requests-timeout ()
   "Timer function called when the pending requests timer expires."
    (let ((channel (caar erc-matterircd--pending-requests)))
      (when channel
        (with-current-buffer (erc-get-buffer channel)
-         (erc-cmd-UPDATELASTVIEWED channel t)))))
+         (erc-matterircd-updatelastviewed channel t)))))
 
 ;; matterircd seems to concatenate multiple privmsg commands if we send
 ;; them too quickly in succession, so instead we want to only send one
 ;; in-flight and queue up the others to be processed later
-(defun erc-cmd-UPDATELASTVIEWED (&optional channel force)
+(defun erc-matterircd-updatelastviewed (&optional channel force)
   "Send updatelastviewed for CHANNEL (or current channel if not specified).
 
 Queue up pending requests so we don't overload matterircd, but
@@ -489,6 +491,8 @@ will always resend if FORCE."
                                   #'erc-matterircd--pending-requests-timeout))))
     (erc-display-message nil 'error channel 'not-matterircd)))
 
+(defalias 'erc-cmd-UPDATELASTVIEWED #'erc-matterircd-updatelastviewed)
+
 (defvar erc-matterircd--last-buffer nil
   "The last matterircd buffer which was viewed.")
 
@@ -501,7 +505,7 @@ will always resend if FORCE."
                (or (null (boundp 'erc-track-mode))
                    (and erc-track-mode
                         (alist-get (current-buffer) erc-modified-channels-alist))))
-      (erc-cmd-UPDATELASTVIEWED))))
+      (erc-matterircd-updatelastviewed))))
 
 (defun erc-matterircd--get-next-context-id (context-ids)
   "Get the next context ID which would be allocated from CONTEXT-IDS."
@@ -525,11 +529,12 @@ will always resend if FORCE."
 (defvar erc-matterircd--run-last-hook-functions
   `(,#'erc-matterircd-buttonize-from-text-properties))
 
+(defvar erc-message-english-not-matterircd
+  "This command is specific to matterircd only.")
+
 (define-erc-module matterircd nil
-  "Integrate ERC with matterircd"
+  "Integrate ERC with matterircd."
   ((add-to-list 'erc-networks-alist '(matterircd "matterircd.*"))
-   (erc-define-catalog-entry 'english 'not-matterircd
-                             "This command is specific to matterircd only.")
    (advice-add #'pcomplete-erc-nicks :around #'erc-matterircd-pcomplete-erc-nicks)
    (add-to-list 'erc-complete-functions #'erc-matterircd-complete-context-ids)
    (add-hook 'erc-after-connect #'erc-matterircd-connect-to-mattermost)


### PR DESCRIPTION
The project lacked any CI, and the existing code had accumulated
issues that violate the MELPA criteria: wrong naming
conventions for ERC command and catalog-entry symbols, obsolete
API usage, docstring style violations, and a bug in scrollback
argument parsing.

**Changes**

- `.github/workflows/main.yml`: replace the old cask/ert-runner CI
  with `leotaku/elisp-check` running MELPA lint and ERT tests across
  Emacs 27.1–30.2 plus snapshot, with `fail-fast: false`
- `erc-matterircd-scrollback`: fix `num-lines` parsing — ERC passes
  command arguments as strings, so `integerp` was always nil; use
  `string-to-number` instead
- Rename `erc-cmd-SCROLLBACK` → `erc-matterircd-scrollback` and
  `erc-cmd-UPDATELASTVIEWED` → `erc-matterircd-updatelastviewed` to
  satisfy package-lint's prefix check; register ERC command dispatch
  names via `fset` (not `defalias`, which package-lint also checks)
- Replace `erc-define-catalog-entry` (obsolete in Emacs 30.1) with
  `set` wrapped in `with-suppressed-warnings` to satisfy both
  package-lint (wrong prefix) and the byte-compiler (free variable)
- Replace `rx` symbol `any` (deprecated in snapshot) with `nonl`
- Fix docstring issues: unescaped single quotes, missing trailing
  period on `define-erc-module`, typo `browse-url-buttton-open-url`
- Fix indentation in several functions

**Testing**

ERT suite (6 tests) passes unchanged. All three local checks pass:
ERT, package-lint, and byte-compilation with no warnings.